### PR TITLE
Redocument to fix CRAN note.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,7 @@
 Package: ggnewscale
 Language: en-GB
-Date: 2022-03-25
 Title: Multiple Fill and Colour Scales in 'ggplot2'
-Version: 0.4.7
+Version: 0.4.8
 Authors@R: 
     person(given = "Elio",
            family = "Campitelli",
@@ -10,11 +9,13 @@ Authors@R:
            email = "elio.campitelli@cima.fcen.uba.ar",
            comment = c(ORCID = "0000-0002-7742-9230"))
 Description: Use multiple fill and colour scales in 'ggplot2'.
+URL: https://eliocamp.github.io/ggnewscale, https://github.com/eliocamp/ggnewscale
+BugReports: https://github.com/eliocamp/ggnewscale/issues
 License: GPL-3
 Encoding: UTF-8
 Imports:
   ggplot2 (>= 3.0.0)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 Suggests: 
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ggnewscale 0.4.8
+
+-   Redocument to fix HTML5 warning on CRAN. No user-visible changes (@jonthegeek).
+
 # ggnewscale 0.4.7
 
 ## Bugfixes

--- a/man/ggnewscale-package.Rd
+++ b/man/ggnewscale-package.Rd
@@ -6,7 +6,7 @@
 \alias{ggnewscale-package}
 \title{ggnewscale: Multiple Fill and Colour Scales in 'ggplot2'}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
 Use multiple fill and colour scales in 'ggplot2'.
 }


### PR DESCRIPTION
https://cran.r-project.org/web/checks/check_results_ggnewscale.html

```
    Found the following HTML validation problems:
    ggnewscale-package.html:23:4: Warning: <img> attribute "align" not allowed for HTML5
```

Also added URL and BugReports to DESCRIPTION to make it easier to help.

I'd be happy to make any changes you need to this!